### PR TITLE
Add Bluesky handle to social links

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,8 @@ export default defineAppConfig({
   socials: {
     twitter: 'KyleMcMaster',
     github: 'KyleMcMaster',
-    mastodon: '@kylemcmaster@fosstodon.org'
+    mastodon: '@kylemcmaster@fosstodon.org',
+    bluesky: 'kylemcmaster.com',
   },
   
   // SEO and site information


### PR DESCRIPTION
This pull request makes a small update to the app's social links configuration by adding a new Bluesky profile to the `socials` section.